### PR TITLE
Improve dataframe memory optimisation utility

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -71,12 +71,16 @@ def iter_mongo_df_chunks(
         for d in docs:
             d.pop("_id", None)
 
-        df = pl.DataFrame(
-            docs,
-            infer_schema_length=None,  # scan all rows, not just first 50
-            nan_to_null=True,  # turn NaN -> null on ingest
-            strict=False,
-        ).fill_null(0.0)
+        df = (
+            pl.DataFrame(
+                docs,
+                infer_schema_length=None,  # scan all rows, not just first 50
+                nan_to_null=True,  # turn NaN -> null on ingest
+                strict=False,
+            )
+            .fill_null(0.0)
+            .shrink_to_fit()
+        )
         logger.info(f"[mongo] yielding chunk rows={len(df)} last_id={last_id}")
         yield df, str(last_id)
         del df

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -2,25 +2,91 @@ import logging
 
 import numpy as np
 import pandas as pd
+from pandas.api import types as ptypes
 
 logger = logging.getLogger(__name__)
 
 
-def reduce_mem_usage(df: pd.DataFrame) -> pd.DataFrame:
-    """Downcast numeric columns to reduce overall memory footprint.
+def _downcast_float(series: pd.Series) -> pd.Series:
+    """Downcast a float ``Series`` as much as possible."""
 
-    The function converts float64 and int64 columns to float32 and int32
-    respectively.  It modifies ``df`` in place and also returns it for
-    convenience so it can be used inline.  A small log message is emitted
-    describing the before/after sizes.
+    f16 = series.astype(np.float16)
+    if np.allclose(series, f16, equal_nan=True):
+        return f16
+    return series.astype(np.float32)
+
+
+def _downcast_int(series: pd.Series) -> pd.Series:
+    """Downcast an integer ``Series`` to the smallest possible subtype."""
+
+    c_min, c_max = series.min(), series.max()
+    if c_min >= 0:
+        # unsigned
+        if c_max <= np.iinfo(np.uint8).max:
+            return series.astype(np.uint8)
+        if c_max <= np.iinfo(np.uint16).max:
+            return series.astype(np.uint16)
+        if c_max <= np.iinfo(np.uint32).max:
+            return series.astype(np.uint32)
+        return series.astype(np.uint64)
+    # signed
+    if np.iinfo(np.int8).min <= c_min and c_max <= np.iinfo(np.int8).max:
+        return series.astype(np.int8)
+    if np.iinfo(np.int16).min <= c_min and c_max <= np.iinfo(np.int16).max:
+        return series.astype(np.int16)
+    if np.iinfo(np.int32).min <= c_min and c_max <= np.iinfo(np.int32).max:
+        return series.astype(np.int32)
+    return series.astype(np.int64)
+
+
+def reduce_mem_usage(df: pd.DataFrame, *, cat_threshold: float = 0.5) -> pd.DataFrame:
+    """Downcast numeric columns and optionally convert objects to categories.
+
+    Parameters
+    ----------
+    df:
+        Dataframe to be modified in-place.
+    cat_threshold:
+        Convert an ``object`` column to ``category`` if its number of unique
+        values divided by the total number of rows is below this threshold.
+
+    Returns
+    -------
+    ``pd.DataFrame``
+        The modified dataframe.  The same object is also modified in-place.
+
+    Notes
+    -----
+    Logs the memory usage before and after the optimisation and returns the
+    dataframe so it can be used inline.
     """
+
     start_mb = df.memory_usage(deep=True).sum() / (1024 ** 2)
-    float_cols = df.select_dtypes(include=["float64"]).columns
-    int_cols = df.select_dtypes(include=["int64"]).columns
-    if len(float_cols):
-        df[float_cols] = df[float_cols].astype(np.float32)
-    if len(int_cols):
-        df[int_cols] = df[int_cols].astype(np.int32)
+
+    for col in df.columns:
+        col_data = df[col]
+        col_type = col_data.dtype
+
+        if ptypes.is_bool_dtype(col_type):
+            df[col] = col_data.astype(bool)
+        elif ptypes.is_integer_dtype(col_type):
+            if col_data.dropna().isin([0, 1]).all():
+                df[col] = col_data.astype(bool)
+            else:
+                df[col] = _downcast_int(col_data)
+        elif ptypes.is_float_dtype(col_type):
+            col_no_na = col_data.dropna()
+            if not col_data.isna().any() and (col_no_na == col_no_na.astype(np.int64)).all():
+                df[col] = _downcast_int(col_data.astype(np.int64))
+            else:
+                df[col] = _downcast_float(col_data)
+        elif ptypes.is_object_dtype(col_type):
+            num_unique = col_data.nunique(dropna=False)
+            if col_data.dropna().isin([0, 1, "0", "1", True, False, "True", "False"]).all():
+                df[col] = col_data.map({"0": False, "1": True, 0: False, 1: True, "True": True, "False": False}).astype(bool)
+            elif num_unique / len(col_data) <= cat_threshold:
+                df[col] = col_data.astype("category")
+
     end_mb = df.memory_usage(deep=True).sum() / (1024 ** 2)
     logger.info(f"[mem] dataframe downcast {start_mb:.2f}MB -> {end_mb:.2f}MB")
     return df

--- a/training.py
+++ b/training.py
@@ -99,6 +99,7 @@ def add_calendar_targets(panel: pd.DataFrame, horizons_days: List[int]):
         panel[mcol] = panel[tcol].replace([np.inf,-np.inf], np.nan).notna().astype(int)
         tcols.append(tcol); mcols.append(mcol)
     logger.info(f"Added calendar targets: cols={tcols}")
+    panel = reduce_mem_usage(panel)
     return panel, tcols, mcols
 
 
@@ -118,6 +119,7 @@ def add_trading_targets(panel: pd.DataFrame, horizons_td: List[int]):
     panel2 = pd.concat(pieces).sort_values([SYMBOL_COL, TIME_COL])
     tcols = [f"target_td{h}" for h in horizons_td]; mcols = [f"mask_td{h}" for h in horizons_td]
     logger.info(f"Added trading targets: cols={tcols}")
+    panel2 = reduce_mem_usage(panel2)
     return panel2, tcols, mcols
 
 # ==========================


### PR DESCRIPTION
## Summary
- expand `reduce_mem_usage` to coerce boolean-like data, downcast integer-like floats, and choose float16 when possible
- shrink Polars DataFrames when iterating Mongo chunks
- apply memory reduction to target-augmentation helpers in training

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a633c7f4248330b55fad8300d5c828