### PR TITLE
Fix training sequence mask handling

### DIFF
--- a/training_step.py
+++ b/training_step.py
@@ -81,7 +81,7 @@ def build_sequences_multi_horizon(panel: pd.DataFrame,
             masks = masks_arr[t]
 
             if require_all:
-                if not np.isfinite(y).all or masks.sum() < H:
+                if not np.isfinite(y).all() or masks.sum() < H:
                     continue
             else:
                 if not np.isfinite(y).any():
@@ -123,8 +123,8 @@ def build_sequences_multi_horizon(panel: pd.DataFrame,
                     continue
 
             win_slice = slice(t - (lookback), t)
-            win_mask = win_slice
-            if not win_mask:
+            win_mask = np.isfinite(feat_arr[win_slice]).all(axis=1)
+            if not win_mask.any():
                 continue
 
             X_Out[idx] = feat_arr[win_slice]


### PR DESCRIPTION
## Summary
- ensure horizon validation checks use the actual finite-value predicate
- build training window masks from feature finiteness instead of storing slice objects

## Testing
- python -m compileall training_step.py

------
https://chatgpt.com/codex/tasks/task_e_68fb0f6d808c83308f6e6785ba4156e2